### PR TITLE
Fixed reload for mp5

### DIFF
--- a/PDBR Update 0.9.3/PDBR/objects/obj_swat/Draw_0.gml
+++ b/PDBR Update 0.9.3/PDBR/objects/obj_swat/Draw_0.gml
@@ -22,3 +22,5 @@ if instance_exists(obj_player)
 		scr_m590()
 	}
 }
+
+draw_text(x, y, string(shotsfired))

--- a/PDBR Update 0.9.3/PDBR/scripts/scr_mp5/scr_mp5.gml
+++ b/PDBR Update 0.9.3/PDBR/scripts/scr_mp5/scr_mp5.gml
@@ -7,14 +7,15 @@ if instance_exists(obj_player) {
 		bullet.image_angle = mpdir
 		bullet.direction = mpdir
 		audio_play_sound(snd_shoten,2,0)
-		alarm[0]=obj_swat.bullet_cooldown
-		obj_swat.shotsfired += 1
+		alarm[0]=bullet_cooldown
+		shotsfired += 1
 	}
 	if !instance_exists(obj_player) {
 		bullet.image_angle = 0
 		bullet.direction = 0
 	}
 }
-if obj_swat.shotsfired >= 15 {
-	alarm[1]=obj_swat.bullet_cooldown = 0
+if shotsfired >= 15 {
+	alarm[0]=game_get_speed(gamespeed_fps) * 2
+	shotsfired = 0
 }


### PR DESCRIPTION
Resetting shots_fired to 0 was the big thing. It takes care of the infinite wait time issue. Other changes were for setting a significant length (game_get_speed(gamespeed_fps) * 2) and removing obj_swat from the variables. It's not needed since scripts automatically pull variables from the object that called it.